### PR TITLE
Change song part label in pianoRoll ruler

### DIFF
--- a/app/PianoRoll/src/main/java/org/jjazz/pianoroll/NotesPanel.java
+++ b/app/PianoRoll/src/main/java/org/jjazz/pianoroll/NotesPanel.java
@@ -109,7 +109,6 @@ public class NotesPanel extends EditorPanel implements PropertyChangeListener
         layer = new JLayer(this, layerUI);
 
         editor.getSettings().addPropertyChangeListener(this);
-
     }
 
     /**
@@ -125,7 +124,7 @@ public class NotesPanel extends EditorPanel implements PropertyChangeListener
     /**
      * Early detection of size changes in order to update xMapper as soon as possible.
      * <p>
-     * Ovverridden because this method is called (by parent's layoutManager) before component is painted and before the component resized/moved event is fired.
+     * Overridden because this method is called (by parent's layoutManager) before component is painted and before the component resized/moved event is fired.
      * This lets us update xMapper as soon as possible.
      *
      * @param x

--- a/app/PianoRoll/src/main/java/org/jjazz/pianoroll/RulerPanel.java
+++ b/app/PianoRoll/src/main/java/org/jjazz/pianoroll/RulerPanel.java
@@ -340,9 +340,13 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
                 var spt = song.getSongStructure().getSongPart(offsettedBar);
                 if (spt.getStartBarIndex() == offsettedBar)
                 {
-                    String text = spt.getName();
+                    String sptName = spt.getName();
+                    String secName = spt.getParentSection().getData().getName();
+                    String sptLabel = sptName.equals(secName)
+                            ? sptName
+                            : String.format("%s(%s)", sptName, secName);
                     StringMetrics sm = new StringMetrics(g2, SMALL_FONT);
-                    var bounds = sm.getLogicalBoundsNoLeadingNoDescent(text);
+                    var bounds = sm.getLogicalBoundsNoLeadingNoDescent(sptLabel);
 
                     // Draw rounded box
                     float PADDING = 1;
@@ -359,7 +363,7 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
                     float xStr = xSongPart + PADDING;
                     g2.setFont(SMALL_FONT);
                     g2.setColor(COLOR_SONG_PART_FONT);
-                    g2.drawString(text, xStr, yTimeSignatureBaseLine);
+                    g2.drawString(sptLabel, xStr, yTimeSignatureBaseLine);
                 }
             }
 
@@ -439,8 +443,8 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
                 if (loopZone.contains(bar))
                 {
                     // Draw a thin rectangle at the bottom
-                    double HEIGHT = 2d;
-                    var r = new Rectangle2D.Double(x, y - HEIGHT + 1, oneBeatPixelSize, HEIGHT);
+                    double RECT_HEIGHT = 2d;
+                    var r = new Rectangle2D.Double(x, y - RECT_HEIGHT + 1, oneBeatPixelSize, RECT_HEIGHT);
                     g2.draw(r);
                     g2.fill(r);
                 }
@@ -470,7 +474,6 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
                 float yStr = yBottomBarLane - 1;           // text baseline position
                 g2.drawString(aStr.getIterator(), xStr, yStr);
             }
-
         }
 
 
@@ -491,8 +494,6 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
             g2.draw(p);
             g2.fill(p);
         }
-
-
     }
 
 
@@ -633,7 +634,6 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
                 clEditor.unselectAll();
                 clEditor.selectItem(cliCs, true);
             }
-
         }
 
         @Override

--- a/app/PianoRoll/src/main/java/org/jjazz/pianoroll/RulerPanel.java
+++ b/app/PianoRoll/src/main/java/org/jjazz/pianoroll/RulerPanel.java
@@ -344,7 +344,7 @@ public class RulerPanel extends JPanel implements PropertyChangeListener
                     String secName = spt.getParentSection().getData().getName();
                     String sptLabel = sptName.equals(secName)
                             ? sptName
-                            : String.format("%s(%s)", sptName, secName);
+                            : sptName + "(" + secName + ")";
                     StringMetrics sm = new StringMetrics(g2, SMALL_FONT);
                     var bounds = sm.getLogicalBoundsNoLeadingNoDescent(sptLabel);
 

--- a/core/SongStructure/src/main/java/org/jjazz/songstructure/SongPartImpl.java
+++ b/core/SongStructure/src/main/java/org/jjazz/songstructure/SongPartImpl.java
@@ -71,7 +71,6 @@ import org.openide.util.lookup.ServiceProvider;
  */
 public class SongPartImpl implements SongPart, Serializable, ChangeListener
 {
-
     public static final String NO_NAME = "NoName";
     /**
      * The rhythm of this part.
@@ -715,7 +714,5 @@ public class SongPartImpl implements SongPart, Serializable, ChangeListener
 
             return newSpt;
         }
-
-
     }
 }

--- a/core/SongStructure/src/main/java/org/jjazz/songstructure/api/SongPart.java
+++ b/core/SongStructure/src/main/java/org/jjazz/songstructure/api/SongPart.java
@@ -39,7 +39,6 @@ import org.jjazz.utilities.api.StringProperties;
  */
 public interface SongPart extends Transferable
 {
-
     /**
      * Fired when a rhythm parameter value has changed.
      * <p>
@@ -48,6 +47,7 @@ public interface SongPart extends Transferable
      * oldValue=rhythm parameter, newValue=value.
      */
     public static final String PROP_RP_VALUE = "SptRpValue";
+
     /**
      * Fired when a mutable value has changed (in addition to the PROP_RP_VALUE change event).
      * <p>


### PR DESCRIPTION
Changes for #545 

The ruler on top of the piano roll had the song part in context. I got the parent section name from the song part and used it.