### PR TITLE
Change interpretation menu logic for fixing #539

### DIFF
--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentHold.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentHold.java
@@ -64,7 +64,6 @@ import org.openide.util.actions.Presenter;
         })
 public final class AccentHold extends AbstractAction implements ContextAwareAction, CL_ContextActionListener, Presenter.Popup, ClsChangeListener
 {
-
     private CL_ContextActionSupport cap;
     private final Lookup context;
     private JRadioButtonMenuItem rbMenuItem;
@@ -211,11 +210,9 @@ public final class AccentHold extends AbstractAction implements ContextAwareActi
         }
         // Update the checkbox: select it if only all chord symbols use Accent Hold
         CL_SelectionUtilities selection = cap.getSelection();
-        boolean b = selection.getSelectedChordSymbols().stream()
+        boolean allChordsHoldAccent = selection.getSelectedChordSymbols().stream()
                 .map(cliCs -> cliCs.getData().getRenderingInfo())
                 .allMatch(cri -> cri.hasOneFeature(Feature.ACCENT, Feature.ACCENT_STRONGER) && cri.hasOneFeature(Feature.HOLD));
-        rbMenuItem.setSelected(b);
-        rbMenuItem.setEnabled(isEnabled());
+        rbMenuItem.setSelected(allChordsHoldAccent);
     }
-
 }

--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentOptionsCrash.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentOptionsCrash.java
@@ -121,14 +121,14 @@ public final class AccentOptionsCrash extends AbstractAction implements ContextA
         }
 
 
-        boolean b = selection.getSelectedChordSymbols().stream()
+        boolean allChordsHaveAccent =  selection.getSelectedChordSymbols().stream()
                 .map(cliCs -> cliCs.getData().getRenderingInfo())
                 .allMatch(cri -> cri.hasOneFeature(Feature.ACCENT, Feature.ACCENT_STRONGER));
-        setEnabled(b);
+        setEnabled(allChordsHaveAccent);
 
         if (dynMenuItem != null)
         {
-            dynMenuItem.setEnabled(b);
+            dynMenuItem.setEnabled(allChordsHaveAccent);
             dynMenuItem.update();
         }
 
@@ -242,7 +242,6 @@ public final class AccentOptionsCrash extends AbstractAction implements ContextA
             ChordRenderingInfo newCri = new ChordRenderingInfo(features, cri.getScaleInstance());
             ExtChordSymbol newCs = ecs.getCopy(null, newCri, ecs.getAlternateChordSymbol(), ecs.getAlternateFilter());
             item.getContainer().changeItem(item, newCs);
-
         }
 
         JJazzUndoManagerFinder.getDefault().get(cls).endCEdit(undoText);
@@ -255,7 +254,7 @@ public final class AccentOptionsCrash extends AbstractAction implements ContextA
     private class MyMenuItem extends JMenuItem implements DynamicMenuContent
     {
 
-        private JComponent[] components = new JComponent[2];
+        private final JComponent[] components = new JComponent[2];
         public JCheckBoxMenuItem cbm_crashAlways;
         public JCheckBoxMenuItem cbm_crashNever;
 
@@ -282,13 +281,15 @@ public final class AccentOptionsCrash extends AbstractAction implements ContextA
             CL_SelectionUtilities selection = cap.getSelection();
 
             boolean crashAlways = selection.getSelectedChordSymbols().stream()
-                    .allMatch(cliCs -> cliCs.getData().getRenderingInfo().hasOneFeature(Feature.CRASH));
+                    .map(cliCs -> cliCs.getData().getRenderingInfo())
+                    .allMatch(cri -> cri.hasOneFeature(Feature.CRASH));
 
             cbm_crashAlways.setSelected(crashAlways);
             cbm_crashAlways.setEnabled(isEnabled());
 
             boolean crashNever = selection.getSelectedChordSymbols().stream()
-                    .allMatch(cliCs -> cliCs.getData().getRenderingInfo().hasOneFeature(Feature.NO_CRASH));
+                    .map(cliCs -> cliCs.getData().getRenderingInfo())
+                    .allMatch(cri -> cri.hasOneFeature(Feature.NO_CRASH));
 
             cbm_crashNever.setSelected(crashNever);
             cbm_crashNever.setEnabled(isEnabled());
@@ -327,8 +328,5 @@ public final class AccentOptionsCrash extends AbstractAction implements ContextA
             }
             changeSelectedChordSymbols(s);
         }
-
-
     }
-
 }

--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentOptionsExtendHoldShot.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentOptionsExtendHoldShot.java
@@ -62,7 +62,6 @@ import org.openide.util.actions.Presenter;
         })
 public final class AccentOptionsExtendHoldShot extends AbstractAction implements ContextAwareAction, CL_ContextActionListener, Presenter.Popup, ClsChangeListener
 {
-
     public static final KeyStroke KEYSTROKE = KeyStroke.getKeyStroke("X");
     private CL_ContextActionSupport cap;
     private final Lookup context;
@@ -118,10 +117,10 @@ public final class AccentOptionsExtendHoldShot extends AbstractAction implements
         }
 
 
-        boolean b = selection.getSelectedChordSymbols().stream()
+        boolean allChordsHoldOrShot = selection.getSelectedChordSymbols().stream()
                 .map(cliCs -> cliCs.getData().getRenderingInfo())
-                .allMatch(cri -> cri.hasOneFeature(Feature.ACCENT, Feature.ACCENT_STRONGER));
-        setEnabled(b);
+                .allMatch(cri -> cri.hasOneFeature(Feature.HOLD, Feature.SHOT));
+        setEnabled(allChordsHoldOrShot);
         updateMenuItem();
     }
 
@@ -220,5 +219,4 @@ public final class AccentOptionsExtendHoldShot extends AbstractAction implements
         cbMenuItem.setSelected(b);
         cbMenuItem.setEnabled(isEnabled());
     }
-
 }

--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentOptionsStronger.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentOptionsStronger.java
@@ -62,7 +62,6 @@ import org.openide.util.actions.Presenter;
         })
 public final class AccentOptionsStronger extends AbstractAction implements ContextAwareAction, CL_ContextActionListener, Presenter.Popup, ClsChangeListener
 {
-
     public static final KeyStroke KEYSTROKE = KeyStroke.getKeyStroke("S");
 
     private CL_ContextActionSupport cap;
@@ -187,12 +186,8 @@ public final class AccentOptionsStronger extends AbstractAction implements Conte
         {
             ExtChordSymbol ecs = item.getData();
             ChordRenderingInfo cri = ecs.getRenderingInfo();
-            if (!cri.hasOneFeature(Feature.ACCENT, Feature.ACCENT_STRONGER))
-            {
-                continue;
-            }
 
-            var features = cri.getFeatures();            
+            var features = cri.getFeatures();
             if (stronger)
             {
                 features.add(Feature.ACCENT_STRONGER);
@@ -220,9 +215,10 @@ public final class AccentOptionsStronger extends AbstractAction implements Conte
 
         // Update the checkbox: select it if only all chord symbols have a Stronger Accent
         CL_SelectionUtilities selection = cap.getSelection();
-        boolean b = selection.getSelectedChordSymbols().stream()
-                .allMatch(cliCs -> cliCs.getData().getRenderingInfo().hasOneFeature(Feature.ACCENT_STRONGER));
-        cbMenuItem.setSelected(b);
+        boolean allChordsStrongerAccent = selection.getSelectedChordSymbols().stream()
+                .map(cliCs -> cliCs.getData().getRenderingInfo())
+                .allMatch(cri -> cri.hasOneFeature(Feature.ACCENT_STRONGER));
+        cbMenuItem.setSelected(allChordsStrongerAccent);
 
         cbMenuItem.setEnabled(isEnabled());
     }

--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentShot.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/AccentShot.java
@@ -64,7 +64,6 @@ import org.openide.util.actions.Presenter;
         })
 public final class AccentShot extends AbstractAction implements ContextAwareAction, CL_ContextActionListener, Presenter.Popup, ClsChangeListener
 {
-
     private CL_ContextActionSupport cap;
     private final Lookup context;
     private JRadioButtonMenuItem rbMenuItem;
@@ -182,9 +181,7 @@ public final class AccentShot extends AbstractAction implements ContextAwareActi
         CL_SelectionUtilities selection = cap.getSelection();
         ChordLeadSheet cls = selection.getChordLeadSheet();
 
-
         JJazzUndoManagerFinder.getDefault().get(cls).startCEdit(undoText);
-
 
         for (CLI_ChordSymbol item : selection.getSelectedChordSymbols())
         {
@@ -211,13 +208,11 @@ public final class AccentShot extends AbstractAction implements ContextAwareActi
         {
             return;
         }
-        // Update the checkbox: select it if only all chord symbols use Accent Hold
+        // Update the checkbox: select it if only all chord symbols use Accent Shot
         CL_SelectionUtilities selection = cap.getSelection();
-        boolean b = selection.getSelectedChordSymbols().stream()
+        boolean allChordsShotAccent = selection.getSelectedChordSymbols().stream()
                 .map(cliCs -> cliCs.getData().getRenderingInfo())
                 .allMatch(cri -> cri.hasOneFeature(Feature.ACCENT, Feature.ACCENT_STRONGER) && cri.hasOneFeature(Feature.SHOT));
-        rbMenuItem.setSelected(b);
-        rbMenuItem.setEnabled(isEnabled());
+        rbMenuItem.setSelected(allChordsShotAccent);
     }
-
 }

--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/Interpretation.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/Interpretation.java
@@ -30,13 +30,6 @@ import javax.swing.Action;
 import javax.swing.JMenu;
 import javax.swing.JMenuItem;
 import javax.swing.JSeparator;
-import org.jjazz.chordleadsheet.api.ChordLeadSheet;
-import org.jjazz.chordleadsheet.api.ClsChangeListener;
-import org.jjazz.chordleadsheet.api.UnsupportedEditException;
-import org.jjazz.chordleadsheet.api.event.ClsChangeEvent;
-import org.jjazz.chordleadsheet.api.event.ItemChangedEvent;
-import org.jjazz.chordleadsheet.api.item.CLI_ChordSymbol;
-import org.jjazz.chordleadsheet.api.item.ChordRenderingInfo;
 import org.jjazz.cl_editor.api.CL_ContextActionListener;
 import org.jjazz.cl_editor.api.CL_ContextActionSupport;
 import org.jjazz.cl_editor.api.CL_SelectionUtilities;
@@ -65,7 +58,6 @@ public final class Interpretation extends AbstractAction implements ContextAware
     private CL_ContextActionSupport cap;
     private final Lookup context;
     JMenu subMenu;
-    private ChordLeadSheet currentCls;
     private static final Logger LOGGER = Logger.getLogger(Interpretation.class.getSimpleName());
 
     public Interpretation()

--- a/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/InterpretationNormal.java
+++ b/app/CL_EditorImpl/src/main/java/org/jjazz/cl_editorimpl/actions/InterpretationNormal.java
@@ -64,7 +64,6 @@ import org.openide.util.actions.Presenter;
         })
 public final class InterpretationNormal extends AbstractAction implements ContextAwareAction, CL_ContextActionListener, Presenter.Popup, ClsChangeListener
 {
-
     private CL_ContextActionSupport cap;
     private final Lookup context;
     private JRadioButtonMenuItem rbMenuItem;
@@ -182,9 +181,7 @@ public final class InterpretationNormal extends AbstractAction implements Contex
         CL_SelectionUtilities selection = cap.getSelection();
         ChordLeadSheet cls = selection.getChordLeadSheet();
 
-
         JJazzUndoManagerFinder.getDefault().get(cls).startCEdit(undoText);
-
 
         for (CLI_ChordSymbol item : selection.getSelectedChordSymbols())
         {
@@ -192,6 +189,8 @@ public final class InterpretationNormal extends AbstractAction implements Contex
             ChordRenderingInfo cri = ecs.getRenderingInfo();
             var features = cri.getFeatures();
             features.remove(Feature.ACCENT);
+            features.remove(Feature.HOLD);
+            features.remove(Feature.SHOT);
             features.remove(Feature.ACCENT_STRONGER);
             ChordRenderingInfo newCri = new ChordRenderingInfo(cri, features);
             ExtChordSymbol newCs = ecs.getCopy(null, newCri, ecs.getAlternateChordSymbol(), ecs.getAlternateFilter());
@@ -209,11 +208,9 @@ public final class InterpretationNormal extends AbstractAction implements Contex
         }
         // Update the checkbox: select it if only all chord symbols do not use accent
         CL_SelectionUtilities selection = cap.getSelection();
-        boolean b = selection.getSelectedChordSymbols().stream()
+        boolean allChordsNoAccent = selection.getSelectedChordSymbols().stream()
                 .map(cliCs -> cliCs.getData().getRenderingInfo())
                 .allMatch(cri -> !cri.hasOneFeature(Feature.ACCENT, Feature.ACCENT_STRONGER));
-        rbMenuItem.setSelected(b);
-        rbMenuItem.setEnabled(isEnabled());
+        rbMenuItem.setSelected(allChordsNoAccent);
     }
-
 }

--- a/core/ChordLeadSheet/src/main/java/org/jjazz/chordleadsheet/api/item/ChordRenderingInfo.java
+++ b/core/ChordLeadSheet/src/main/java/org/jjazz/chordleadsheet/api/item/ChordRenderingInfo.java
@@ -97,13 +97,13 @@ public class ChordRenderingInfo implements Serializable
         /**
          * Make sure there is no crash cymbal.
          * <p>
-         * IMPORTANT: Exclusive with NO_CRASH
+         * IMPORTANT: Exclusive with CRASH
          */
         NO_CRASH,
         /**
          * Make sure there is a crash cymbal.
          * <p>
-         * IMPORTANT: Exclusive with CRASH
+         * IMPORTANT: Exclusive with NO_CRASH
          */
         CRASH,
         /**
@@ -229,16 +229,11 @@ public class ChordRenderingInfo implements Serializable
      * <p>
      * Convenience method because of EnumSet...
      *
-     * @param f1
      * @param fx
      * @return
      */
-    public boolean hasAllFeatures(Feature f1, Feature... fx)
+    public boolean hasAllFeatures(Feature... fx)
     {
-        if (!features.contains(f1))
-        {
-            return false;
-        }
         return features.containsAll(Arrays.asList(fx));
     }
 
@@ -247,16 +242,11 @@ public class ChordRenderingInfo implements Serializable
      * <p>
      * Convenience method because of EnumSet...
      *
-     * @param f1
      * @param fx
      * @return
      */
-    public boolean hasOneFeature(Feature f1, Feature... fx)
+    public boolean hasOneFeature(Feature... fx)
     {
-        if (features.contains(f1))
-        {
-            return true;
-        }
         for (Feature f : fx)
         {
             if (features.contains(f))

--- a/core/ChordLeadSheet/src/main/java/org/jjazz/chordleadsheet/api/item/ChordRenderingInfo.java
+++ b/core/ChordLeadSheet/src/main/java/org/jjazz/chordleadsheet/api/item/ChordRenderingInfo.java
@@ -495,7 +495,7 @@ public class ChordRenderingInfo implements Serializable
             }
         }
 
-        private Object readResolve() throws ObjectStreamException
+        protected Object readResolve() throws ObjectStreamException
         {
             if (spPlayStyleV1 != null)
             {

--- a/core/ChordLeadSheet/src/main/java/org/jjazz/chordleadsheet/api/item/ExtChordSymbol.java
+++ b/core/ChordLeadSheet/src/main/java/org/jjazz/chordleadsheet/api/item/ExtChordSymbol.java
@@ -48,10 +48,10 @@ import static org.jjazz.xstream.spi.XStreamConfigurator.InstanceId.SONG_SAVE;
 import org.openide.util.lookup.ServiceProvider;
 
 /**
- * An extended chord symbol with additionnal features:
+ * An extended chord symbol with additional features:
  * <p>
  * - Chord rendering information<br>
- * - An optional conditionnally-enabled alternate chord symbol.
+ * - An optional conditionally-enabled alternate chord symbol.
  * <p>
  * This is an immutable class.
  */


### PR DESCRIPTION
I aligned the logic of the interpretation menu with the comments ion ChordRenderingInfo.Feature (it was mostly following that already).

Enabling also follows the comments, e.g. EXTENDED_HOLD_SHOT is ignored if not HOLD or shot, so the item is disabled unless one of those is active. All features are kept even if not active, with the exception of ACCENT_STRONGER, that has to be discarded when interpretation normal is selected.

There's a tricky change in ChordRenderingInfo. I changed the API from _hasAllFeatures(Feature f1, Feature ... fx)_ to just _hasAllFeatures(Feature ... fx)_. That's source code compatible but any client would need to recompile against the new bytecode. I realized but kept it to check what you think, I'm ok reverting that. Same for _hasOneFeatures_.