### PR TITLE
Fix fresh build (no maven builds of jjazzlab modules) for #554

### DIFF
--- a/core/Harmony/src/main/java/org/jjazz/harmony/api/TimeSignature.java
+++ b/core/Harmony/src/main/java/org/jjazz/harmony/api/TimeSignature.java
@@ -25,7 +25,6 @@ package org.jjazz.harmony.api;
 import com.google.common.base.Preconditions;
 import java.text.ParseException;
 import java.util.List;
-import java.util.Objects;
 import java.util.logging.Logger;
 import org.jjazz.utilities.api.FloatRange;
 import org.jjazz.utilities.api.ResUtil;

--- a/core/Song/pom.xml
+++ b/core/Song/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -12,7 +11,7 @@
     <artifactId>song</artifactId>
     <name>Song</name>
     <packaging>nbm</packaging>
-    
+
     <properties>
         <jjazzlab.surefire.skipTests>false</jjazzlab.surefire.skipTests>
     </properties>     
@@ -24,101 +23,86 @@
                 <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
-                    <publicPackages>                      
+                    <publicPackages>
                         <publicPackage>org.jjazz.song.api</publicPackage>
                         <publicPackage>org.jjazz.song.spi</publicPackage>
                     </publicPackages>
                 </configuration>
                 <extensions>true</extensions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <additionalClasspathDependencies>
-                        <!-- Add those modules only for test runtime so that RhythmDatabase is populated -->
-                        <additionalClasspathDependency>
-                            <groupId>org.jjazzlab.plugins</groupId>
-                            <artifactId>yamjjazz</artifactId>       
-                            <version>${project.version}</version>
-                        </additionalClasspathDependency>
-                        <additionalClasspathDependency>
-                            <groupId>org.jjazzlab.core</groupId>
-                            <artifactId>rhythmstubs</artifactId>       
-                            <version>${project.version}</version>
-                        </additionalClasspathDependency>                        
-                    </additionalClasspathDependencies>
-                </configuration>
-            </plugin>            
-            
+            </plugin>
         </plugins>
     </build>
-    <dependencies>  
-        <dependency> 
+
+    <dependencies>
+        <dependency>
             <groupId>org.jjazzlab.core</groupId>
             <artifactId>guava</artifactId>
             <version>${project.version}</version>
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>harmony</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>chordleadsheet</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>phrase</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>quantizer</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>rhythm</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>rhythmdatabase</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>songstructure</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>undomanager</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>utilities</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.netbeans.api</groupId> 
-            <artifactId>org-openide-dialogs</artifactId> 
-            <version>${netbeans.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.netbeans.api</groupId> 
-            <artifactId>org-openide-util</artifactId> 
-            <version>${netbeans.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.netbeans.api</groupId> 
-            <artifactId>org-openide-util-lookup</artifactId> 
-            <version>${netbeans.version}</version>  
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>harmony</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>chordleadsheet</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>phrase</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>quantizer</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>rhythm</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>rhythmdatabase</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>songstructure</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>undomanager</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>utilities</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-dialogs</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-lookup</artifactId>
+            <version>${netbeans.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jjazzlab.core</groupId>
@@ -138,6 +122,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-  
 </project>
-

--- a/core/Song/src/main/resources/org/jjazz/song/api/Bundle.properties
+++ b/core/Song/src/main/resources/org/jjazz/song/api/Bundle.properties
@@ -1,3 +1,5 @@
 ErrCantOverrideSong=Can not overwrite {0}
 EDIT_ME=Edit me...
 ERR_ProblemSavingSongFile=Problem saving song file {0}
+DUMMY_RHYTHMS=Dummy rhythms
+DUMMY_RHYTHMS_DESC=Provides a dummy rhythm for each time signature

--- a/core/Song/src/test/java/org/jjazz/song/api/SongAdaptedRhythmStub.java
+++ b/core/Song/src/test/java/org/jjazz/song/api/SongAdaptedRhythmStub.java
@@ -1,0 +1,151 @@
+/*
+ * 
+ *   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *  
+ *   Copyright @2019 Jerome Lelasseux. All rights reserved.
+ * 
+ *   This file is part of the JJazzLab software.
+ *    
+ *   JJazzLab is free software: you can redistribute it and/or modify
+ *   it under the terms of the Lesser GNU General Public License (LGPLv3) 
+ *   as published by the Free Software Foundation, either version 3 of the License, 
+ *   or (at your option) any later version.
+ * 
+ *   JJazzLab is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *  
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with JJazzLab.  If not, see <https://www.gnu.org/licenses/>
+ *  
+ *   Contributor(s): 
+ * 
+ */
+package org.jjazz.song.api;
+
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.List;
+import org.jjazz.harmony.api.TimeSignature;
+import org.jjazz.rhythm.api.AdaptedRhythm;
+import org.jjazz.rhythm.api.MusicGenerationException;
+import org.jjazz.rhythm.api.Rhythm;
+import org.jjazz.rhythm.api.RhythmFeatures;
+import org.jjazz.rhythm.api.RhythmParameter;
+import org.jjazz.rhythm.api.RhythmVoice;
+
+/**
+ * An AdaptedRhyhtm for RhythmStub.
+ */
+public class SongAdaptedRhythmStub implements AdaptedRhythm
+{
+    private final SongRhythmStub sourceRhythm;
+    private final TimeSignature timeSignature;
+
+    public SongAdaptedRhythmStub(SongRhythmStub r, TimeSignature ts)
+    {
+        if (r.getTimeSignature().equals(ts))
+        {
+            throw new IllegalArgumentException("r=" + r + " ts=" + ts);
+        }
+        sourceRhythm = r;
+        timeSignature = ts;
+    }
+
+    @Override
+    public Rhythm getSourceRhythm()
+    {
+        return sourceRhythm;
+    }
+
+    @Override
+    public String getUniqueId()
+    {
+        return AdaptedRhythm.buildUniqueId(SongRhythmStubProviderImpl.ID, sourceRhythm, timeSignature);
+    }
+
+    @Override
+    public RhythmFeatures getFeatures()
+    {
+        return sourceRhythm.getFeatures();
+    }
+
+    @Override
+    public void loadResources() throws MusicGenerationException
+    {
+        // Nothing
+    }
+
+    @Override
+    public void releaseResources()
+    {
+        // Nothing
+    }
+
+    @Override
+    public boolean isResourcesLoaded()
+    {
+        return true;
+    }
+
+    @Override
+    public List<RhythmVoice> getRhythmVoices()
+    {
+        return sourceRhythm.getRhythmVoices();
+    }
+
+    @Override
+    public List<RhythmParameter<?>> getRhythmParameters()
+    {
+        return sourceRhythm.getRhythmParameters();
+    }
+
+    @Override
+    public File getFile()
+    {
+        return new File("");
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return getName() + " - adapted rhythm";
+    }
+
+    @Override
+    public int getPreferredTempo()
+    {
+        return sourceRhythm.getPreferredTempo();
+    }
+
+    @Override
+    public TimeSignature getTimeSignature()
+    {
+        return timeSignature;
+    }
+
+    @Override
+    public String getName()
+    {
+        return sourceRhythm.getName() + "[" + timeSignature + "]";
+    }
+
+    @Override
+    public String getAuthor()
+    {
+        return sourceRhythm.getAuthor();
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+}

--- a/core/Song/src/test/java/org/jjazz/song/api/SongRhythmStub.java
+++ b/core/Song/src/test/java/org/jjazz/song/api/SongRhythmStub.java
@@ -1,0 +1,238 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright @2019 Jerome Lelasseux. All rights reserved.
+ *
+ *  This file is part of the JJazzLab software.
+ *   
+ *  JJazzLab is free software: you can redistribute it and/or modify
+ *  it under the terms of the Lesser GNU General Public License (LGPLv3) 
+ *  as published by the Free Software Foundation, either version 3 of the License, 
+ *  or (at your option) any later version.
+ *
+ *  JJazzLab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with JJazzLab.  If not, see <https://www.gnu.org/licenses/>
+ * 
+ *  Contributor(s): 
+ */
+package org.jjazz.song.api;
+
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Logger;
+import org.jjazz.harmony.api.TimeSignature;
+import org.jjazz.midi.api.DrumKit;
+import org.jjazz.midi.api.DrumKit.Type;
+import org.jjazz.midi.api.synths.GM1Bank;
+import org.jjazz.midi.api.keymap.KeyMapGM;
+import org.jjazz.midi.api.synths.InstrumentFamily;
+import org.jjazz.midi.api.synths.GMSynth;
+import org.jjazz.rhythm.api.Division;
+import org.jjazz.rhythm.api.Genre;
+import org.jjazz.rhythm.api.Rhythm;
+import org.jjazz.rhythm.api.RhythmFeatures;
+import org.jjazz.rhythm.api.RhythmVoice;
+import org.jjazz.rhythm.api.rhythmparameters.RP_SYS_Variation;
+import org.jjazz.rhythm.api.RhythmParameter;
+import org.jjazz.rhythm.api.TempoRange;
+
+/**
+ * A rhythm stub whatever the time signature.
+ * <p>
+ */
+public class SongRhythmStub implements Rhythm
+{
+
+    private final String uniqueId;
+    private final TimeSignature timeSignature;
+    private final RhythmFeatures features;
+    /**
+     * The default RhythmParameters associated to this rhythm.
+     */
+    private final ArrayList<RhythmParameter<?>> rhythmParameters = new ArrayList<>();
+    /**
+     * The supported RhythmVoices.
+     */
+    private final ArrayList<RhythmVoice> rhythmVoices = new ArrayList<>();
+    private static final Logger LOGGER = Logger.getLogger(SongRhythmStub.class.getSimpleName());
+
+    /**
+     * Create a dummy rhythm for specified time signature.
+     *
+     *
+     * @param uniqueId
+     * @param ts
+     */
+    public SongRhythmStub(String uniqueId, TimeSignature ts, RhythmFeatures fs)
+    {
+        if (uniqueId == null || uniqueId.trim().isEmpty() || ts == null|| fs == null)
+        {
+            throw new IllegalArgumentException("uniqueId=" + uniqueId + " ts=" + ts);
+        }
+
+        this.uniqueId = uniqueId;
+        this.timeSignature = ts;
+        this.features = fs;
+
+        // Rhythm voices
+        GM1Bank gmb = GMSynth.getInstance().getGM1Bank();
+        rhythmVoices.add(new RhythmVoice(new DrumKit(Type.STANDARD, KeyMapGM.getInstance()), this, RhythmVoice.Type.DRUMS, "Drums",
+                GMSynth.getInstance().getVoidInstrument(), 9));
+        rhythmVoices.add(new RhythmVoice(this, RhythmVoice.Type.BASS, "Bass", gmb.getDefaultInstrument(InstrumentFamily.Bass), 10));
+
+        // Our Rhythm Parameters
+        rhythmParameters.add(new RP_SYS_Variation(true));
+    }
+
+    // ==============================================================================================
+    // Rhythm interface
+    // ==============================================================================================
+
+    @Override
+    public boolean equals(Object o)
+    {
+        boolean res = false;
+        if (o instanceof SongRhythmStub)
+        {
+            SongRhythmStub rs = (SongRhythmStub) o;
+            res = rs.uniqueId.equals(uniqueId);
+        }
+        return res;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 5;
+        hash = 47 * hash + Objects.hashCode(this.uniqueId);
+        return hash;
+    }
+
+    @Override
+    public List<RhythmVoice> getRhythmVoices()
+    {
+        return new ArrayList<>(rhythmVoices);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RhythmParameter<?>> getRhythmParameters()
+    {
+        return new ArrayList<>(rhythmParameters);
+    }
+
+    @Override
+    public TimeSignature getTimeSignature()
+    {
+        return timeSignature;
+    }
+
+    @Override
+    public void loadResources()
+    {
+    }
+
+    /**
+     *
+     * @return true
+     */
+    @Override
+    public boolean isResourcesLoaded()
+    {
+        return true;
+    }
+
+    /**
+     * This implementation does nothing.
+     */
+    @Override
+    public void releaseResources()
+    {
+        // Do nothing
+    }
+
+    @Override
+    public int compareTo(Rhythm o)
+    {
+        return getName().compareTo(o.getName());
+    }
+
+    @Override
+    public File getFile()
+    {
+        return new File("");
+    }
+
+    @Override
+    public RhythmFeatures getFeatures()
+    {
+//        return new RhythmFeatures();
+//        return new RhythmFeatures(Genre.LATIN, Division.BINARY, TempoRange.ALL_TEMPO);
+        return features;
+    }
+
+    @Override
+    public String getUniqueId()
+    {
+        return uniqueId;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Dummy description";
+    }
+
+    @Override
+    public int getPreferredTempo()
+    {
+        return 120;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "JuanName-" + getTimeSignature().toString();
+    }
+
+    @Override
+    public String getAuthor()
+    {
+        return "JL";
+    }
+
+    @Override
+    public String[] getTags()
+    {
+        return new String[]
+        {
+            "dummy"
+        };
+    }
+
+    @Override
+    public String toString()
+    {
+        return getName();
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+}

--- a/core/Song/src/test/java/org/jjazz/song/api/SongRhythmStubProviderImpl.java
+++ b/core/Song/src/test/java/org/jjazz/song/api/SongRhythmStubProviderImpl.java
@@ -1,0 +1,149 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright @2019 Jerome Lelasseux. All rights reserved.
+ *
+ *  This file is part of the JJazzLab software.
+ *
+ *  JJazzLab is free software: you can redistribute it and/or modify
+ *  it under the terms of the Lesser GNU General Public License (LGPLv3)
+ *  as published by the Free Software Foundation, either version 3 of the License,
+ *  or (at your option) any later version.
+ *
+ *  JJazzLab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with JJazzLab.  If not, see <https://www.gnu.org/licenses/>
+ *
+ *  Contributor(s):
+ */
+package org.jjazz.song.api;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jjazz.harmony.api.TimeSignature;
+import org.jjazz.rhythm.api.Division;
+import org.jjazz.rhythm.api.Genre;
+import org.jjazz.rhythm.api.Rhythm;
+import org.jjazz.rhythm.api.RhythmFeatures;
+import org.jjazz.rhythm.api.TempoRange;
+import org.jjazz.rhythm.spi.RhythmProvider;
+import org.jjazz.utilities.api.MultipleErrorsReport;
+import org.jjazz.rhythm.spi.StubRhythmProvider;
+import org.jjazz.utilities.api.ResUtil;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+@ServiceProviders(value =
+{
+    @ServiceProvider(service = StubRhythmProvider.class),
+    @ServiceProvider(service = RhythmProvider.class)            // So that it appears in the Rhythm selection dialog box
+}
+)
+public class SongRhythmStubProviderImpl implements StubRhythmProvider
+{
+
+    public static final String ID = "StubRhythmProviderID";
+    private Info info;
+    private ArrayList<Rhythm> rhythms = new ArrayList<>();
+
+    public SongRhythmStubProviderImpl()
+    {
+        info = new Info(ID, ResUtil.getString(getClass(), "DUMMY_RHYTHMS"), ResUtil.getString(getClass(), "DUMMY_RHYTHMS_DESC"), "JL", "1.0");
+        for (Division div : Division.values())
+        {
+            for (TimeSignature ts : TimeSignature.values())
+            {
+                rhythms.add(new SongRhythmStub("RhythmStubID-" + ts.toString(), ts,
+                        new RhythmFeatures(Genre.BALLROOM, div, TempoRange.ALL_TEMPO)));
+            }
+        }
+        System.out.println("=================== RHYTHMS CREATED =============================");
+    }
+
+    @Override
+    public Rhythm getStubRhythm(TimeSignature ts)
+    {
+        if (ts == null)
+        {
+            throw new NullPointerException("ts");
+        }
+        Rhythm res = null;
+        for (Rhythm r : rhythms)
+        {
+            if (r.getTimeSignature().equals(ts))
+            {
+                res = r;
+                break;
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public void showUserSettingsDialog()
+    {
+        // Nothing
+    }
+
+    /**
+     * Return true if RhythmProvider has settings which can be modified by end-user.
+     * <p>
+     *
+     * @return @see showUserSettingsDialog()
+     */
+    @Override
+    public boolean hasUserSettings()
+    {
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return info.getName();
+    }
+
+    @Override
+    public Info getInfo()
+    {
+        return info;
+    }
+
+    @Override
+    public List<Rhythm> getBuiltinRhythms(MultipleErrorsReport errRpt)
+    {
+        return new ArrayList<>(rhythms);
+    }
+
+    @Override
+    public List<Rhythm> getFileRhythms(boolean forceRescan, MultipleErrorsReport errRpt)
+    {
+        return new ArrayList<>();
+    }
+
+
+    @Override
+    public String[] getSupportedFileExtensions()
+    {
+        return new String[0];
+    }
+
+    @Override
+    public Rhythm readFast(File f) throws IOException
+    {
+        throw new IOException("This RhythmProvider (" + getInfo().getName() + ") does not support file reading.");
+    }
+
+    @Override
+    public SongAdaptedRhythmStub getAdaptedRhythm(Rhythm r, TimeSignature ts)
+    {
+        var res = (r instanceof SongRhythmStub rs) ? new SongAdaptedRhythmStub(rs, ts) : null;
+        return res;
+    }
+}

--- a/core/SongStructure/pom.xml
+++ b/core/SongStructure/pom.xml
@@ -1,4 +1,3 @@
-
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -12,102 +11,87 @@
     <artifactId>songstructure</artifactId>
     <name>SongStructure</name>
     <packaging>nbm</packaging>
-    
+
     <properties>
         <jjazzlab.surefire.skipTests>false</jjazzlab.surefire.skipTests>
-    </properties>     
-    
+    </properties>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.netbeans.utilities</groupId>
                 <artifactId>nbm-maven-plugin</artifactId>
                 <configuration>
-                    <publicPackages>                      
+                    <publicPackages>
                         <publicPackage>org.jjazz.songstructure.api</publicPackage>
                         <publicPackage>org.jjazz.songstructure.api.event</publicPackage>
                     </publicPackages>
                 </configuration>
                 <extensions>true</extensions>
             </plugin>
-            
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <additionalClasspathDependencies>
-                        <!-- Add those modules only for test runtime so that RhythmDatabase is populated -->
-                        <additionalClasspathDependency>
-                            <groupId>org.jjazzlab.plugins</groupId>
-                            <artifactId>yamjjazz</artifactId>       
-                            <version>${project.version}</version>
-                        </additionalClasspathDependency>
-                        <additionalClasspathDependency>
-                            <groupId>org.jjazzlab.core</groupId>
-                            <artifactId>rhythmstubs</artifactId>       
-                            <version>${project.version}</version>
-                        </additionalClasspathDependency>                        
-                    </additionalClasspathDependencies>
-                </configuration>
-            </plugin>            
-            
+            </plugin>
         </plugins>
     </build>
-    <dependencies>      
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>harmony</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>chordleadsheet</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>rhythm</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>rhythmdatabase</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>undomanager</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.jjazzlab.core</groupId> 
-            <artifactId>utilities</artifactId> 
-            <version>${project.version}</version>  
-        </dependency>  
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>harmony</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>chordleadsheet</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>rhythm</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>rhythmdatabase</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>undomanager</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jjazzlab.core</groupId>
+            <artifactId>utilities</artifactId>
+            <version>${project.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.jjazzlab.core</groupId>
             <artifactId>xstream</artifactId>
             <version>${project.version}</version>
-        </dependency>        
+        </dependency>
         <dependency>
             <groupId>org.jjazzlab.core</groupId>
             <artifactId>guava</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency> 
-            <groupId>org.netbeans.api</groupId> 
-            <artifactId>org-openide-dialogs</artifactId> 
-            <version>${netbeans.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.netbeans.api</groupId> 
-            <artifactId>org-openide-util</artifactId> 
-            <version>${netbeans.version}</version>  
-        </dependency>  
-        <dependency> 
-            <groupId>org.netbeans.api</groupId> 
-            <artifactId>org-openide-util-lookup</artifactId> 
-            <version>${netbeans.version}</version>  
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-dialogs</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util</artifactId>
+            <version>${netbeans.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.netbeans.api</groupId>
+            <artifactId>org-openide-util-lookup</artifactId>
+            <version>${netbeans.version}</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -123,4 +107,3 @@
         </dependency>
     </dependencies>
 </project>
-

--- a/core/SongStructure/src/main/resources/org/jjazz/songstructure/Bundle.properties
+++ b/core/SongStructure/src/main/resources/org/jjazz/songstructure/Bundle.properties
@@ -1,2 +1,4 @@
 ERR_RhythmNotFound=Rhythm not found
 ERR_UsingReplacementRhythm=Using replacement rhythm
+DUMMY_RHYTHMS=Dummy rhythms
+DUMMY_RHYTHMS_DESC=Provides a dummy rhythm for each time signature

--- a/core/SongStructure/src/test/java/org/jjazz/songstructure/SongAdaptedRhythmStub.java
+++ b/core/SongStructure/src/test/java/org/jjazz/songstructure/SongAdaptedRhythmStub.java
@@ -1,0 +1,151 @@
+/*
+ * 
+ *   DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *  
+ *   Copyright @2019 Jerome Lelasseux. All rights reserved.
+ * 
+ *   This file is part of the JJazzLab software.
+ *    
+ *   JJazzLab is free software: you can redistribute it and/or modify
+ *   it under the terms of the Lesser GNU General Public License (LGPLv3) 
+ *   as published by the Free Software Foundation, either version 3 of the License, 
+ *   or (at your option) any later version.
+ * 
+ *   JJazzLab is distributed in the hope that it will be useful,
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *   GNU Lesser General Public License for more details.
+ *  
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with JJazzLab.  If not, see <https://www.gnu.org/licenses/>
+ *  
+ *   Contributor(s): 
+ * 
+ */
+package org.jjazz.songstructure;
+
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.List;
+import org.jjazz.harmony.api.TimeSignature;
+import org.jjazz.rhythm.api.AdaptedRhythm;
+import org.jjazz.rhythm.api.MusicGenerationException;
+import org.jjazz.rhythm.api.Rhythm;
+import org.jjazz.rhythm.api.RhythmFeatures;
+import org.jjazz.rhythm.api.RhythmParameter;
+import org.jjazz.rhythm.api.RhythmVoice;
+
+/**
+ * An AdaptedRhyhtm for RhythmStub.
+ */
+public class SongAdaptedRhythmStub implements AdaptedRhythm
+{
+    private final SongRhythmStub sourceRhythm;
+    private final TimeSignature timeSignature;
+
+    public SongAdaptedRhythmStub(SongRhythmStub r, TimeSignature ts)
+    {
+        if (r.getTimeSignature().equals(ts))
+        {
+            throw new IllegalArgumentException("r=" + r + " ts=" + ts);
+        }
+        sourceRhythm = r;
+        timeSignature = ts;
+    }
+
+    @Override
+    public Rhythm getSourceRhythm()
+    {
+        return sourceRhythm;
+    }
+
+    @Override
+    public String getUniqueId()
+    {
+        return AdaptedRhythm.buildUniqueId(SongRhythmStubProviderImpl.ID, sourceRhythm, timeSignature);
+    }
+
+    @Override
+    public RhythmFeatures getFeatures()
+    {
+        return sourceRhythm.getFeatures();
+    }
+
+    @Override
+    public void loadResources() throws MusicGenerationException
+    {
+        // Nothing
+    }
+
+    @Override
+    public void releaseResources()
+    {
+        // Nothing
+    }
+
+    @Override
+    public boolean isResourcesLoaded()
+    {
+        return true;
+    }
+
+    @Override
+    public List<RhythmVoice> getRhythmVoices()
+    {
+        return sourceRhythm.getRhythmVoices();
+    }
+
+    @Override
+    public List<RhythmParameter<?>> getRhythmParameters()
+    {
+        return sourceRhythm.getRhythmParameters();
+    }
+
+    @Override
+    public File getFile()
+    {
+        return new File("");
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return getName() + " - adapted rhythm";
+    }
+
+    @Override
+    public int getPreferredTempo()
+    {
+        return sourceRhythm.getPreferredTempo();
+    }
+
+    @Override
+    public TimeSignature getTimeSignature()
+    {
+        return timeSignature;
+    }
+
+    @Override
+    public String getName()
+    {
+        return sourceRhythm.getName() + "[" + timeSignature + "]";
+    }
+
+    @Override
+    public String getAuthor()
+    {
+        return sourceRhythm.getAuthor();
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+}

--- a/core/SongStructure/src/test/java/org/jjazz/songstructure/SongRhythmStub.java
+++ b/core/SongStructure/src/test/java/org/jjazz/songstructure/SongRhythmStub.java
@@ -1,0 +1,237 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ * 
+ *  Copyright @2019 Jerome Lelasseux. All rights reserved.
+ *
+ *  This file is part of the JJazzLab software.
+ *   
+ *  JJazzLab is free software: you can redistribute it and/or modify
+ *  it under the terms of the Lesser GNU General Public License (LGPLv3) 
+ *  as published by the Free Software Foundation, either version 3 of the License, 
+ *  or (at your option) any later version.
+ *
+ *  JJazzLab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ * 
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with JJazzLab.  If not, see <https://www.gnu.org/licenses/>
+ * 
+ *  Contributor(s): 
+ */
+package org.jjazz.songstructure;
+
+import java.beans.PropertyChangeListener;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.logging.Logger;
+import org.jjazz.harmony.api.TimeSignature;
+import org.jjazz.midi.api.DrumKit;
+import org.jjazz.midi.api.DrumKit.Type;
+import org.jjazz.midi.api.synths.GM1Bank;
+import org.jjazz.midi.api.keymap.KeyMapGM;
+import org.jjazz.midi.api.synths.InstrumentFamily;
+import org.jjazz.midi.api.synths.GMSynth;
+import org.jjazz.rhythm.api.Division;
+import org.jjazz.rhythm.api.Genre;
+import org.jjazz.rhythm.api.Rhythm;
+import org.jjazz.rhythm.api.RhythmFeatures;
+import org.jjazz.rhythm.api.RhythmVoice;
+import org.jjazz.rhythm.api.rhythmparameters.RP_SYS_Variation;
+import org.jjazz.rhythm.api.RhythmParameter;
+import org.jjazz.rhythm.api.TempoRange;
+
+/**
+ * A rhythm stub whatever the time signature.
+ * <p>
+ */
+public class SongRhythmStub implements Rhythm
+{
+
+    private final String uniqueId;
+    private final TimeSignature timeSignature;
+    /**
+     * The default RhythmParameters associated to this rhythm.
+     */
+    private final ArrayList<RhythmParameter<?>> rhythmParameters = new ArrayList<>();
+    /**
+     * The supported RhythmVoices.
+     */
+    private final ArrayList<RhythmVoice> rhythmVoices = new ArrayList<>();
+    private static final Logger LOGGER = Logger.getLogger(SongRhythmStub.class.getSimpleName());
+
+    /**
+     * Create a dummy rhythm for specified time signature.
+     *
+     *
+     * @param uniqueId
+     * @param ts
+     */
+    public SongRhythmStub(String uniqueId, TimeSignature ts)
+    {
+        if (uniqueId == null || uniqueId.trim().isEmpty() || ts == null)
+        {
+            throw new IllegalArgumentException("uniqueId=" + uniqueId + " ts=" + ts);
+        }
+
+        this.uniqueId = uniqueId;
+        this.timeSignature = ts;
+
+        // Rhythm voices
+        GM1Bank gmb = GMSynth.getInstance().getGM1Bank();
+        rhythmVoices.add(new RhythmVoice(new DrumKit(Type.STANDARD, KeyMapGM.getInstance()), this, RhythmVoice.Type.DRUMS, "Drums",
+                GMSynth.getInstance().getVoidInstrument(), 9));
+        rhythmVoices.add(new RhythmVoice(this, RhythmVoice.Type.BASS, "Bass", gmb.getDefaultInstrument(InstrumentFamily.Bass), 10));
+
+        // Our Rhythm Parameters
+        rhythmParameters.add(new RP_SYS_Variation(true));
+    }
+
+    // ==============================================================================================
+    // Rhythm interface
+    // ==============================================================================================
+
+    @Override
+    public boolean equals(Object o)
+    {
+        boolean res = false;
+        if (o instanceof SongRhythmStub)
+        {
+            SongRhythmStub rs = (SongRhythmStub) o;
+            res = rs.uniqueId.equals(uniqueId);
+        }
+        return res;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int hash = 5;
+        hash = 47 * hash + Objects.hashCode(this.uniqueId);
+        return hash;
+    }
+
+    @Override
+    public List<RhythmVoice> getRhythmVoices()
+    {
+        return new ArrayList<>(rhythmVoices);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public List<RhythmParameter<?>> getRhythmParameters()
+    {
+        return new ArrayList<>(rhythmParameters);
+    }
+
+    @Override
+    public TimeSignature getTimeSignature()
+    {
+        return timeSignature;
+    }
+
+    @Override
+    public void loadResources()
+    {
+    }
+
+    /**
+     *
+     * @return true
+     */
+    @Override
+    public boolean isResourcesLoaded()
+    {
+        return true;
+    }
+
+    /**
+     * This implementation does nothing.
+     */
+    @Override
+    public void releaseResources()
+    {
+        // Do nothing
+    }
+
+    @Override
+    public int compareTo(Rhythm o)
+    {
+        return getName().compareTo(o.getName());
+    }
+
+    @Override
+    public File getFile()
+    {
+        return new File("");
+    }
+
+    @Override
+    public RhythmFeatures getFeatures()
+    {
+//        return new RhythmFeatures();
+        return new RhythmFeatures(Genre.LATIN, Division.BINARY, TempoRange.ALL_TEMPO);
+    }
+
+    @Override
+    public String getUniqueId()
+    {
+        return uniqueId;
+    }
+
+    @Override
+    public String getDescription()
+    {
+        return "Dummy description";
+    }
+
+    @Override
+    public int getPreferredTempo()
+    {
+        return 120;
+    }
+
+    @Override
+    public String getName()
+    {
+        return "JuanName-" + getTimeSignature().toString();
+    }
+
+    @Override
+    public String getAuthor()
+    {
+        return "JL";
+    }
+
+    @Override
+    public String[] getTags()
+    {
+        return new String[]
+        {
+            "dummy"
+        };
+    }
+
+    @Override
+    public String toString()
+    {
+        return getName();
+    }
+
+    @Override
+    public void addPropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+
+    @Override
+    public void removePropertyChangeListener(PropertyChangeListener l)
+    {
+        // Nothing
+    }
+
+
+}

--- a/core/SongStructure/src/test/java/org/jjazz/songstructure/SongRhythmStubProviderImpl.java
+++ b/core/SongStructure/src/test/java/org/jjazz/songstructure/SongRhythmStubProviderImpl.java
@@ -1,0 +1,140 @@
+/*
+ *  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS HEADER.
+ *
+ *  Copyright @2019 Jerome Lelasseux. All rights reserved.
+ *
+ *  This file is part of the JJazzLab software.
+ *
+ *  JJazzLab is free software: you can redistribute it and/or modify
+ *  it under the terms of the Lesser GNU General Public License (LGPLv3)
+ *  as published by the Free Software Foundation, either version 3 of the License,
+ *  or (at your option) any later version.
+ *
+ *  JJazzLab is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public License
+ *  along with JJazzLab.  If not, see <https://www.gnu.org/licenses/>
+ *
+ *  Contributor(s):
+ */
+package org.jjazz.songstructure;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.jjazz.harmony.api.TimeSignature;
+import org.jjazz.rhythm.api.Rhythm;
+import org.jjazz.rhythm.spi.RhythmProvider;
+import org.jjazz.utilities.api.MultipleErrorsReport;
+import org.jjazz.rhythm.spi.StubRhythmProvider;
+import org.jjazz.utilities.api.ResUtil;
+import org.openide.util.lookup.ServiceProvider;
+import org.openide.util.lookup.ServiceProviders;
+
+@ServiceProviders(value =
+{
+    @ServiceProvider(service = StubRhythmProvider.class),
+    @ServiceProvider(service = RhythmProvider.class)            // So that it appears in the Rhythm selection dialog box
+}
+)
+public class SongRhythmStubProviderImpl implements StubRhythmProvider
+{
+
+    public static final String ID = "StubRhythmProviderID";
+    private Info info;
+    private ArrayList<Rhythm> rhythms = new ArrayList<>();
+
+    public SongRhythmStubProviderImpl()
+    {
+        info = new Info(ID, ResUtil.getString(getClass(), "DUMMY_RHYTHMS"), ResUtil.getString(getClass(), "DUMMY_RHYTHMS_DESC"), "JL", "1.0");
+        for (TimeSignature ts : TimeSignature.values())
+        {
+            rhythms.add(new SongRhythmStub("RhythmStubID-" + ts.toString(), ts));
+        }
+    }
+
+    @Override
+    public Rhythm getStubRhythm(TimeSignature ts)
+    {
+        if (ts == null)
+        {
+            throw new NullPointerException("ts");
+        }
+        Rhythm res = null;
+        for (Rhythm r : rhythms)
+        {
+            if (r.getTimeSignature().equals(ts))
+            {
+                res = r;
+                break;
+            }
+        }
+        return res;
+    }
+
+    @Override
+    public void showUserSettingsDialog()
+    {
+        // Nothing
+    }
+
+    /**
+     * Return true if RhythmProvider has settings which can be modified by end-user.
+     * <p>
+     *
+     * @return @see showUserSettingsDialog()
+     */
+    @Override
+    public boolean hasUserSettings()
+    {
+        return false;
+    }
+
+    @Override
+    public String toString()
+    {
+        return info.getName();
+    }
+
+    @Override
+    public Info getInfo()
+    {
+        return info;
+    }
+
+    @Override
+    public List<Rhythm> getBuiltinRhythms(MultipleErrorsReport errRpt)
+    {
+        return new ArrayList<>(rhythms);
+    }
+
+    @Override
+    public List<Rhythm> getFileRhythms(boolean forceRescan, MultipleErrorsReport errRpt)
+    {
+        return new ArrayList<>();
+    }
+
+
+    @Override
+    public String[] getSupportedFileExtensions()
+    {
+        return new String[0];
+    }
+
+    @Override
+    public Rhythm readFast(File f) throws IOException
+    {
+        throw new IOException("This RhythmProvider (" + getInfo().getName() + ") does not support file reading.");
+    }
+
+    @Override
+    public SongAdaptedRhythmStub getAdaptedRhythm(Rhythm r, TimeSignature ts)
+    {
+        var res = (r instanceof SongRhythmStub rs) ? new SongAdaptedRhythmStub(rs, ts) : null;
+        return res;
+    }
+}


### PR DESCRIPTION
The blocking issue for a fresh build are the classpath dependencies on RhythmStubs and Yamjjazz. They were used for tests in Song and SongStructure.

I copied and modified some mocking classes from RhythmStubs, then got rid of the classpath dependency. Not great but it makes the trick.

DRAFT - I want to experiment and get a better solution. If I don't we can always use this PR as is.